### PR TITLE
feat:가게부 주간별 가게부 데이터 API 변경

### DIFF
--- a/src/account-book-list/account-book-list.service.ts
+++ b/src/account-book-list/account-book-list.service.ts
@@ -67,12 +67,12 @@ export class AccountBookListService {
   ): Promise<WeekAccountBookListDto[]> {
     const Result = getConnection()
       .createQueryBuilder()
-      .select(['amount', 'inOutType', 'bookDateRange'])
+      .select(['inComeAmount', 'outGoingAmount', 'bookDateRange'])
       .from((subQuery) => {
         return subQuery
           .select([
-            'sum(amount) as amount',
-            'inOutType',
+            `SUM((CASE WHEN inOutType='inCome' THEN amount ELSE 0 END)) as inComeAmount`,
+            `SUM((CASE WHEN inOutType='outGoing' THEN amount ELSE 0 END)) as outGoingAmount`,
             `CONCAT(DATE_FORMAT(DATE_ADD(bookDate,
               INTERVAL(1-DAYOFWEEK(bookDate)) DAY),"%Y.%m.%d")," - ",DATE_FORMAT(DATE_ADD(bookDate,
               INTERVAL(7-DAYOFWEEK(bookDate)) DAY),"%Y.%m.%d")) AS bookDateRange`,
@@ -84,7 +84,7 @@ export class AccountBookListService {
             { searchStartDate, searchEndDate },
           ).groupBy(`CONCAT(DATE_FORMAT(DATE_ADD(bookDate,
             INTERVAL(1-DAYOFWEEK(bookDate)) DAY),"%Y.%m.%d")," - ",DATE_FORMAT(DATE_ADD(bookDate,
-            INTERVAL(7-DAYOFWEEK(bookDate)) DAY),"%Y.%m.%d")),inOutType`);
+            INTERVAL(7-DAYOFWEEK(bookDate)) DAY),"%Y.%m.%d"))`);
       }, 'res')
       .orderBy('res.bookDateRange', 'DESC')
       .getRawMany();

--- a/src/account-book-list/dto/week-account-book-list.dto.ts
+++ b/src/account-book-list/dto/week-account-book-list.dto.ts
@@ -1,4 +1,6 @@
 import { AccountBookListBaseDto } from './account-book-list.dto';
 export class WeekAccountBookListDto extends AccountBookListBaseDto {
   readonly bookDateRange: string;
+  readonly inComeAmount: number;
+  readonly outGoingAmount: number;
 }


### PR DESCRIPTION
주간별 가게부 정리데이터를 수입,지출을  칼럼을 나누는것보단 카테고리별로 합을 같은 한 칼럼에 같이 구하는것이 프론트의 내용 출력에서도 나을것 같다는 판단하게 변경

- 관련이슈: #28 